### PR TITLE
Refactored node helper to allow specifiying multiple evdev readers

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -12,113 +12,118 @@ const Log = require("logger");
 var evdev;
 var udev;
 
-module.exports = NodeHelper.create({
-  start: function () {
-    Log.log("MMM-KeyBindings helper has started…");
-    this.evdevMonitorCreated = false;
-  },
-
-  stop: function () {
-    if (this.evdevMonitorCreated) {
-      Log.log("EVDEV: Closing monitor and reader");
-      try {
-        this.udevMonitor.close();
-      } catch (e) {
-        if (
-          e.toString().indexOf("Cannot read property 'close' of undefined") ===
-          -1
-        ) {
-          Log.error(e);
-        }
-      }
-      try {
-        this.evdevReader.close();
-      } catch (e) {
-        Log.error(e);
-      }
+class EvDevHandler {
+    constructor(path, udev, onKeyPress) {
+        this.evdevPath = path;
+        this.udev = udev;
+        this.onKey = onKeyPress;
+        Log.log("Create EvDevHandler for " + path);
     }
-  },
 
-  waitForDevice: function () {
-    this.udevMonitor = udev.monitor();
-    this.udevMonitor.on("add", (device) => {
-      if (
-        "DEVLINKS" in device &&
-        device.DEVLINKS === this.evdevConfig.eventPath
-      ) {
-        Log.log("UDEV: Device connected.");
-        this.udevMonitor.close();
+    close() {
+        Log.log("EVDEV: Closing monitor and reader of " + this.evdevPath);
+        try {
+            this.udevMonitor.close();
+        } catch (e) {
+            if (e.toString().indexOf("Cannot read property 'close' of undefined") === -1) {
+                Log.error(e);
+            }
+        }
+        try {
+            this.evdevReader.close();
+        } catch (e) {
+            Log.error(e);
+        }
+    }
+
+    startMonitor() {
+        this.evdevReader = new evdev();
+        this.pendingKeyPress = {};
+
+        this.evdevReader
+        .on("EV_KEY", (data) => {
+            // Log.log("key : ", data.code, data.value);
+            if (data.value > 0) {
+                this.pendingKeyPress.code = data.code;
+                this.pendingKeyPress.value = data.value;
+            } else {
+                if ("code" in this.pendingKeyPress && this.pendingKeyPress.code === data.code) {
+                    Log.log(`${this.pendingKeyPress.code} ${this.pendingKeyPress.value === 2 ? "long " : ""}pressed.`);
+                    this.onKey(data.code, this.pendingKeyPress.value === 2 ? "KEY_LONGPRESSED" : "KEY_PRESSED");
+                }
+                this.pendingKeyPress = {};
+            }
+        })
+        .on("error", (e) => {
+            if (e.code === "ENODEV" || e.code === "ENOENT") {
+                Log.info(`EVDEV: Device not connected, nothing at path ${e.path}, waiting for device…`);
+                this.waitForDevice();
+            } else {
+                Log.error("EVDEV: ", e);
+            }
+        });
+
         this.setupDevice();
-      }
-    });
-  },
-
-  setupDevice: function () {
-    this.device = this.evdevReader.open(this.evdevConfig.eventPath);
-    this.device.on("open", () => {
-      Log.log(`EVDEV: Connected to device: ${JSON.stringify(this.device.id)}`);
-    });
-    this.device.on("close", () => {
-      Log.debug(`EVDEV: Connection to device has been closed.`);
-      this.waitForDevice();
-    });
-  },
-
-  startEvdevMonitor: function () {
-    evdev = require("evdev");
-    udev = require("udev");
-
-    this.evdevMonitorCreated = true;
-    this.evdevReader = new evdev();
-    this.pendingKeyPress = {};
-
-    this.evdevReader
-      .on("EV_KEY", (data) => {
-        // Log.log("key : ", data.code, data.value);
-        if (data.value > 0) {
-          this.pendingKeyPress.code = data.code;
-          this.pendingKeyPress.value = data.value;
-        } else {
-          if (
-            "code" in this.pendingKeyPress &&
-            this.pendingKeyPress.code === data.code
-          ) {
-            Log.log(
-              `${this.pendingKeyPress.code} ${
-                this.pendingKeyPress.value === 2 ? "long " : ""
-              }pressed.`
-            );
-            this.sendSocketNotification("KEYPRESS", {
-              keyName: data.code,
-              keyState:
-                this.pendingKeyPress.value === 2
-                  ? "KEY_LONGPRESSED"
-                  : "KEY_PRESSED"
-            });
-          }
-          this.pendingKeyPress = {};
-        }
-      })
-      .on("error", (e) => {
-        if (e.code === "ENODEV" || e.code === "ENOENT") {
-          Log.info(
-            `EVDEV: Device not connected, nothing at path ${e.path}, waiting for device…`
-          );
-          this.waitForDevice();
-        } else {
-          Log.error("EVDEV: ", e);
-        }
-      });
-
-    this.setupDevice();
-  },
-
-  socketNotificationReceived: function (notification, payload) {
-    if (notification === "ENABLE_EVDEV") {
-      if (!this.evdevMonitorCreated) {
-        this.evdevConfig = payload;
-        this.startEvdevMonitor();
-      }
     }
-  }
+
+    setupDevice() {
+        this.device = this.evdevReader.open(this.evdevPath);
+        this.device.on("open", () => {
+            Log.log(`EVDEV: Connected to device: ${JSON.stringify(this.device.id)}`);
+        });
+        this.device.on("close", () => {
+            Log.debug(`EVDEV: Connection to device has been closed.`);
+            this.waitForDevice();
+        });
+    }
+
+    waitForDevice() {
+        this.udevMonitor = this.udev.monitor();
+        this.udevMonitor.on("add", (device) => {
+            if ("DEVLINKS" in device && device.DEVLINKS === this.evdevPath) {
+                Log.log("UDEV: Device connected.");
+                this.udevMonitor.close();
+                this.setupDevice();
+            }
+        });
+    }
+
+}
+
+module.exports = NodeHelper.create({
+    start: function () {
+        Log.log("MMM-KeyBindings helper has started…");
+        this.evdevMonitorCreated = false;
+        this.handlers = [];
+    },
+
+    stop: function () {
+        if (this.evdevMonitorCreated) {
+            handlers.forEach(h => {
+                h.close();
+            });
+        }
+    },
+
+
+    socketNotificationReceived: function (notification, payload) {
+		var self = this;
+        if (notification === "ENABLE_EVDEV") {
+            if (!this.evdevMonitorCreated) {
+                evdev = require('evdev');
+                udev = require('udev');
+                var paths = payload.eventPath.split(",");
+                this.handlers = paths.map(p => new EvDevHandler(p, udev, (name, state) => {
+                            self.sendSocketNotification("KEYPRESS", {
+                                keyName: name,
+                                keyState: state
+                            });
+                        }));
+                this.handlers.forEach(h => {
+                    h.startMonitor();
+                });
+                this.evdevMonitorCreated = true;
+            }
+        }
+    }
 });


### PR DESCRIPTION
I use a weird 2.4GHz Remote for my MM, that reports itself as 3 input devices...
Two of them being a "keyboard" style device, one being a "accelerometer mouse"...whatever..

Anyhow, I wanted to accumulate the key presses from the two "keyboards" into my MM.

I thought it might be a simple approach to just encapsulate the evdev reading into a class and allow the config to have a comma separated eventPath value specifying more than one input source.

For example:
` config: {
                 evdev: {
                     enabled: true,
					 eventPath: "/dev/input/event0,/dev/input/event2",
                 },
}`

So i did that any quickly tested it.
All events end up being in the same socketNotification pipe, so the MM itself sees no source-distinction - which for me is fine.

I have basically not much knowledge about evdev and udev, so please correct me if that is nonsense..

I think it is a fancy addition to the module :)

